### PR TITLE
[Level6] 일정 단건 조회 업그레이드

### DIFF
--- a/src/main/java/com/todolist/controller/TodoController.java
+++ b/src/main/java/com/todolist/controller/TodoController.java
@@ -23,7 +23,7 @@ public class TodoController {
         return ResponseEntity.status(HttpStatus.OK).body(todoService.findOne(todoId));
     }
     @GetMapping("/todo-list")
-    public ResponseEntity<List<GetOneTodoResponse>> getAllTodos(@RequestParam(required=false) String username) {
+    public ResponseEntity<List<GetAllTodoResponse>> getAllTodos(@RequestParam(required=false) String username) {
         return ResponseEntity.status(HttpStatus.OK).body(todoService.findAll(username));
     }
     @PatchMapping("/todo-list/{todoId}")

--- a/src/main/java/com/todolist/dto/GetAllTodoResponse.java
+++ b/src/main/java/com/todolist/dto/GetAllTodoResponse.java
@@ -3,25 +3,22 @@ package com.todolist.dto;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
-public class GetOneTodoResponse {
+public class GetAllTodoResponse {
     private final Long id;
     private final String username;
     private final String title;
     private final String description;
     private final LocalDateTime createdAt;
     private final LocalDateTime modifiedAt;
-    private final List<GetOneCommentResponse> comments;
 
-    public GetOneTodoResponse(Long id, String username, String title, String description, LocalDateTime createdAt, LocalDateTime modifiedAt, List<GetOneCommentResponse> comments) {
+    public GetAllTodoResponse(Long id, String username, String title, String description, LocalDateTime createdAt, LocalDateTime modifiedAt) {
         this.id = id;
         this.username = username;
         this.title = title;
         this.description = description;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
-        this.comments = comments;
     }
 }

--- a/src/main/java/com/todolist/dto/GetOneCommentResponse.java
+++ b/src/main/java/com/todolist/dto/GetOneCommentResponse.java
@@ -1,0 +1,21 @@
+package com.todolist.dto;
+
+import com.todolist.entity.Comment;
+import lombok.Getter;
+
+@Getter
+public class GetOneCommentResponse {
+    private final Long id;
+    private final String username;
+    private final String content;
+    private final String createdAt;
+    private final String modifiedAt;
+
+    public GetOneCommentResponse(Comment comment) {
+        this.id = comment.getId();
+        this.username = comment.getUsername();
+        this.content = comment.getContent();
+        this.createdAt = comment.getCreatedAt().toString();
+        this.modifiedAt = comment.getModifiedAt().toString();
+    }
+}

--- a/src/main/java/com/todolist/service/TodoService.java
+++ b/src/main/java/com/todolist/service/TodoService.java
@@ -47,16 +47,15 @@ public class TodoService {
     }
 
     @Transactional(readOnly = true)
-    public List<GetOneTodoResponse> findAll(String username) {
+    public List<GetAllTodoResponse> findAll(String username) {
         List<Todo> todos;
         if (username != null) {
             todos = todoRepository.findAllByUsernameOrderByCreatedAtDesc(username);
         } else {
             todos = todoRepository.findAllByOrderByCreatedAtDesc();
         }
-
         return todos.stream()
-                .map(todo -> new GetOneTodoResponse(
+                .map(todo -> new GetAllTodoResponse(
                         todo.getId(),
                         todo.getUsername(),
                         todo.getTitle(),
@@ -69,13 +68,17 @@ public class TodoService {
     @Transactional(readOnly = true)
     public GetOneTodoResponse findOne(Long todoId) {
         Todo todo = findTodoOrException(todoId);
+        List<GetOneCommentResponse> commentResponses = todo.getComments().stream()
+                .map(GetOneCommentResponse::new)
+                .toList();
         return new GetOneTodoResponse(
                 todo.getId(),
                 todo.getUsername(),
                 todo.getTitle(),
                 todo.getDescription(),
                 todo.getCreatedAt(),
-                todo.getModifiedAt()
+                todo.getModifiedAt(),
+                commentResponses
         );
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,6 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+logging.level.org.hibernate=DEBUG
+logging.level.org.springframework.orm.jpa=DEBUG
+logging.level.org.springframework.boot.autoconfigure.orm.jpa=DEBUG


### PR DESCRIPTION
- comment 도메인의 GetOneCommentResponse DTO 클래스 추가
- 기존 getOneTodoResponse에 List<GetOneCommentResponse> 필드 추가
- 하나의 Todo글에 연관된 댓글 목록 조회해서 DTO 담아 반환
- 다건 조회용 DTO 클래스 분리해 생성
- 단건 조회시 Todo 조회1번, Todo의 목록 조회 1번 해서 N+1 문제 발생 -> Repository에서 findById에 @EntityGraph 어노테이션 맵핑 (lv7에서 수정)